### PR TITLE
the "=" sign in this file is not English symbol,

### DIFF
--- a/langs/locale_en-us.ini
+++ b/langs/locale_en-us.ini
@@ -27,9 +27,9 @@ edit = Edit
 old_password = Old Password：
 new_password = New Password：
 cfm_password = Cofirm Password：
-input_db_name ＝ Please input database name
+input_db_name = Please input database name
 database_connstr = Connection string:
-database_connstr_hint ＝ Please input database connection string
+database_connstr_hint = Please input database connection string
 affected_desc = Execution finished, %d records affected.
 login_title = Log In
 password_not_eq = confirm password is not equal to new password


### PR DESCRIPTION
this will cause below error and end up en-US locale file can't be loaded

error parsing line: key-value delimiter not found: input_db_name ＝ Please input database name
