### PR TITLE
fix sqlite3

### DIFF
--- a/actions/addb.go
+++ b/actions/addb.go
@@ -45,8 +45,12 @@ func (c *Addb) Post() {
 	username := c.Form("username")
 	passwd := c.Form("passwd")
 
-	engine.DataSource = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8",
-		username, passwd, host, port, dbname)
+	if engine.Driver == "sqlite3" {
+		engine.DataSource = host
+	} else {
+		engine.DataSource = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8",
+			username, passwd, host, port, dbname)
+	}
 
 	/*if err := c.MapForm(&engine); err != nil {
 		c.Flash.Set("ErrAdd", i18n.Tr(c.CurLang(), "err_param"))

--- a/actions/sqlite.go
+++ b/actions/sqlite.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	SupportDBs = append(SupportDBs, "sqlite3")
+	SupportDBs = append(SupportDBs, DB{"sqlite3", 0})
 }


### PR DESCRIPTION
Fix the following 2 problems 

1. compile err
actions/sqlite.go:10: cannot use "sqlite3" (type string) as type DB in append

2. sqlite3 can not be use
When access sqlite3 db，web show error “unable to open database file”

In this PR，sqlite3 will only use host field， so place the db file path in host field。

Now it’s work。